### PR TITLE
Provide livedown functions as vim commands

### DIFF
--- a/plugin/livedown.vim
+++ b/plugin/livedown.vim
@@ -1,3 +1,6 @@
+command LivedownPreview :call LivedownPreview()
+command LivedownKill :call LivedownKill()
+
 if !exists('g:livedown_autorun')
   let g:livedown_autorun = 0
 endif


### PR DESCRIPTION
This change will let you call the functions with
```
:LivedownPreview
```
instead of having to type
```
:call LivedownPreview()
```