### PR TITLE
Use commands instead of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,24 @@ Then install this plugin with your preferred installation method. I recommend in
 
     $ git clone git://github.com/shime/vim-livedown.git ~/.vim/bundle/vim-livedown
 
+## Usage
+
+There are the commands that you can use:
+
+```vimscript
+" launch the Livedown server and preview your markdown file
+:LivedownPreview
+
+" stop the Livedown server
+:LivedownKill		
+```
+
+Feel free to set your own mapping:
+
+```vimscript
+nmap gm :LivedownPreview<CR>
+```
+
 ## Configuration
 
 There are several configuration variables you can customize to suit your needs, with the following defaults.
@@ -29,12 +47,6 @@ let g:livedown_open = 1
 
 " the port on which Livedown server will run
 let g:livedown_port = 1337
-```
-
-There is also a global function you can call explicitly for previews
-
-```vimscript
-map gm :call LivedownPreview()<CR>
 ```
 
 ## License

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,7 +1,7 @@
 augroup livedown
   if g:livedown_autorun
-    au! BufWinEnter <buffer> call LivedownPreview()
+    au! BufWinEnter <buffer> LivedownPreview
   endif
 
-  au! VimLeave <buffer> call LivedownKill()
+  au! VimLeave <buffer> LivedownKill
 augroup END

--- a/ftplugin/mkd.vim
+++ b/ftplugin/mkd.vim
@@ -1,7 +1,7 @@
 augroup livedown
   if g:livedown_autorun
-    au! BufWinEnter <buffer> call LivedownPreview()
+    au! BufWinEnter <buffer> LivedownPreview
   endif
 
-  au! VimLeave <buffer> call LivedownKill()
+  au! VimLeave <buffer> LivedownKill
 augroup END

--- a/plugin/livedown.vim
+++ b/plugin/livedown.vim
@@ -1,5 +1,5 @@
-command! LivedownPreview :call LivedownPreview()
-command! LivedownKill :call LivedownKill()
+command! LivedownPreview :call s:LivedownPreview()
+command! LivedownKill :call s:LivedownKill()
 
 if !exists('g:livedown_autorun')
   let g:livedown_autorun = 0
@@ -13,13 +13,13 @@ if !exists('g:livedown_port')
   let g:livedown_port = 1337
 endif
 
-function! LivedownPreview()
+function! s:LivedownPreview()
   call system("livedown start '" . expand('%:p') . "'" .
         \ (g:livedown_open ? " --open" : "") .
         \ " --port " . g:livedown_port .
         \ " &")
 endfunction
 
-function! LivedownKill()
+function! s:LivedownKill()
   call system("livedown stop --port " . g:livedown_port . " &")
 endfunction

--- a/plugin/livedown.vim
+++ b/plugin/livedown.vim
@@ -1,5 +1,5 @@
-command LivedownPreview :call LivedownPreview()
-command LivedownKill :call LivedownKill()
+command! LivedownPreview :call LivedownPreview()
+command! LivedownKill :call LivedownKill()
 
 if !exists('g:livedown_autorun')
   let g:livedown_autorun = 0


### PR DESCRIPTION
Hi.

First of all, thanks for your awesome work, livedown is really nice :smiley:

I'm not a vimscript expert but there are some advices and also explanations of my PR:
- Always use **!** with `command` to avoid errors when resourcing a vim script containing the same command (Your `vimrc` for example).
- For a common use, vim commands are better than functions when you want to map them.

English not being my mother tongue, I could have made some spelling errors in the README, check it if you want.