### PR TITLE
Windows support

### DIFF
--- a/plugin/livedown.vim
+++ b/plugin/livedown.vim
@@ -15,14 +15,24 @@ if !exists('g:livedown_port')
 endif
 
 function! s:LivedownPreview()
-  call system("livedown start '" . expand('%:p') . "'" .
-        \ (g:livedown_open ? " --open" : "") .
-        \ " --port " . g:livedown_port .
-        \ " &")
+  if has('win32')
+    silent! call system("start /B " . "livedown start \"" . expand('%:p') . "\"" .
+      \ (g:livedown_open ? " --open" : "") .
+      \ " --port " . g:livedown_port)
+  else 
+    call system("livedown start '" . expand('%:p') . "'" .
+      \ (g:livedown_open ? " --open" : "") .
+      \ " --port " . g:livedown_port .
+      \ " &")
+  endif
 endfunction
 
 function! s:LivedownKill()
-  call system("livedown stop --port " . g:livedown_port . " &")
+  if has('win32')
+    silent! call system("start /B livedown stop --port " . g:livedown_port)
+  else 
+    call system("livedown stop --port " . g:livedown_port . " &")
+  endif
 endfunction
 
 function! s:LivedownToggle()


### PR DESCRIPTION
Allows plugin to work on windows machines using the cmd.exe shell. Fixes #5.

#5 is caused by the `&` character being improperly escaped. In Windows, starting a process in the background uses the `start /B` command instead. 

I'm not sure why, but unfortunately the `start` command cannot write to the temp file created by vim, so the error specified in #5 is back, though for a different reason. **Functionality is not affected**, so I've just hidden the error away with vim's `:silent` command for now.