### PR TITLE
Make "browser" flag optional

### DIFF
--- a/plugin/livedown.vim
+++ b/plugin/livedown.vim
@@ -14,21 +14,17 @@ if !exists('g:livedown_port')
   let g:livedown_port = 1337
 endif
 
-if !exists('g:livedown_browser')
-  let g:livedown_browser = "firefox"
-endif
-
 function! s:LivedownPreview()
   if has('win32')
     silent! call system("start /B " . "livedown start \"" . expand('%:p') . "\"" .
       \ (g:livedown_open ? " --open" : "") .
       \ " --port " . g:livedown_port .
-      \ " --browser " . g:livedown_browser)
+      \ (exists('g:livedown_browser') ? " --browser " . g:livedown_browser : ""))
   else 
     call system("livedown start '" . expand('%:p') . "'" .
       \ (g:livedown_open ? " --open" : "") .
       \ " --port " . g:livedown_port .
-      \ " --browser " . g:livedown_browser .
+      \ (exists('g:livedown_browser') ? " --browser " . g:livedown_browser : "") .
       \ " &")
   endif
 endfunction


### PR DESCRIPTION
On Windows, having a default command of 'firefox' would not launch the
browser. By passing no parameter livedown will use the command 'start'
which launches the users default browser.

See #21 