### PR TITLE
Fix OSX no longer opening pages in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ let g:livedown_open = 1
 
 " the port on which Livedown server will run
 let g:livedown_port = 1337
+
+" the system command to launch a browser (ex. on linux)
+let g:livedown_browser = firefox
+
+" the system command to launch a browser (ex. on OSX)
+let g:livedown_browser = "open /Applications/Firefox.app"
 ```
 
 ## License

--- a/plugin/livedown.vim
+++ b/plugin/livedown.vim
@@ -14,21 +14,17 @@ if !exists('g:livedown_port')
   let g:livedown_port = 1337
 endif
 
-if !exists('g:livedown_browser')
-  let g:livedown_browser = "firefox"
-endif
-
 function! s:LivedownPreview()
   if has('win32')
     silent! call system("start /B " . "livedown start \"" . expand('%:p') . "\"" .
       \ (g:livedown_open ? " --open" : "") .
       \ " --port " . g:livedown_port .
-      \ " --browser " . g:livedown_browser)
+      \ (exists(g:livedown_browser) ? " --browser " . g:livedown_browser : "")
   else 
     call system("livedown start '" . expand('%:p') . "'" .
       \ (g:livedown_open ? " --open" : "") .
+      \ (exists("g:livedown_browser") ? " --browser " . g:livedown_browser : "") .
       \ " --port " . g:livedown_port .
-      \ " --browser " . g:livedown_browser .
       \ " &")
   endif
 endfunction


### PR DESCRIPTION
### Bug:
`g:livedown_browser = "firefox"` is the default.
This translates to a node `exec firefox <url>` in  `livedown`.
On OSX `firefox` is not on the path.

### Solution:
`g:livedown_browser` is unset by default.
The `--browser` flag is not passed.
The system launcher (ex. `open` on OSX), is used to open the url.

### Commentary:
`livedown` has the assumption that `--browser` is optional, when it's not
provided, it uses the system's launcher (ex. `open` on OSX). `vim-livedown`
should be the same way.

**Disclaimer:**
I did not test on `linux` or `windows`. I did test on `OSX` including what was added to the documentation.