### PR TITLE
Fixed issue with variable not being defined

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -1,5 +1,5 @@
 augroup livedown
-  if g:livedown_autorun
+  if get(g:, 'livedown_autorun', 0)
     au! BufWinEnter <buffer> LivedownPreview
   endif
 

--- a/ftplugin/mkd.vim
+++ b/ftplugin/mkd.vim
@@ -1,5 +1,5 @@
 augroup livedown
-  if g:livedown_autorun
+  if get(g:, 'livedown_autorun', 0)
     au! BufWinEnter <buffer> LivedownPreview
   endif
 

--- a/plugin/livedown.vim
+++ b/plugin/livedown.vim
@@ -2,10 +2,6 @@ command! LivedownPreview :call s:LivedownPreview()
 command! LivedownKill :call s:LivedownKill()
 command! LivedownToggle :call s:LivedownToggle()
 
-if !exists('g:livedown_autorun')
-  let g:livedown_autorun = 0
-endif
-
 if !exists('g:livedown_open')
   let g:livedown_open = 1
 endif


### PR DESCRIPTION
Before:

    Error detected while processing ~/.vim/plugged/vim-livedown/ftplugin/markdown.vim:
    line    2:
    E121: Undefined variable: g:livedown_autorun
    E15: Invalid expression: g:livedown_autorun
    Press ENTER or type command to continue

After:

    No errors

Note: I have `filetype detect` in my config so that I can reload my
config without issue. However, this causes this plugin to not work
correctly since the filetype event is triggered before
plugin/livedown.vim has been loaded.