### PR TITLE
Fix chrome not launching on macOS

### DIFF
--- a/plugin/livedown.vim
+++ b/plugin/livedown.vim
@@ -23,6 +23,16 @@ if !exists('g:livedown_command')
   endif
 endif
 
+function! s:LivedownBrowser()
+  if g:livedown_browser == "chrome" && has('macunix')
+    let l:browser = "'Google Chrome'"
+  else
+    let l:browser = g:livedown_browser
+  endif
+
+  return '"' . l:browser . '"'
+endfunction
+
 function! s:LivedownRun(command)
   let a:platform_command = has('win32') ?
     \ "start /B " . a:command :
@@ -35,10 +45,12 @@ function! s:LivedownRun(command)
 endfunction
 
 function! s:LivedownPreview()
-  call s:LivedownRun(g:livedown_command . " start \"" . expand('%:p') . "\"" .
+  let l:command = g:livedown_command . " start \"" . expand('%:p') . "\"" .
       \ (g:livedown_open ? " --open" : "") .
       \ " --port " . g:livedown_port .
-      \ (exists("g:livedown_browser") ? " --browser " . g:livedown_browser : ""))
+      \ (exists("g:livedown_browser") ? " --browser " . s:LivedownBrowser() : "")
+
+  call s:LivedownRun(command)
 endfunction
 
 function! s:LivedownKill()


### PR DESCRIPTION
Fixes #27 

According to the issue, this works (and I confirm it works for me):

```shell
$ livedown start README.md --browser "'Google Chrome'" --open
```

However, setting `g:livedown_browser` to `google-chrome` or `"Google Chrome"` wouldn't work because vim was escaping some quotes.

This change addresses it by escaping the browser variable to always have quotes (doesn't affect other browsers besides Chrome, I tested it myself). And also setting the option for `chrome` to change to `Google Chrome` in macs, in order to be backwards compatible with existing configs -- mine had `chrome` and just stopped working.