### PR TITLE
Allow flexible names for chrome.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Vim plugin for [Livedown](https://github.com/shime/livedown).
 
 ## Installation
 
-First make sure you have [node](http://nodejs.org/) with [npm](https://www.npmjs.org/) installed. 
+First make sure you have [node](http://nodejs.org/) with [npm](https://www.npmjs.org/) installed.
 
 If you have node do
 
@@ -46,12 +46,12 @@ There are several configuration variables you can customize to suit your needs, 
 let g:livedown_autorun = 0
 
 " should the browser window pop-up upon previewing
-let g:livedown_open = 1 
+let g:livedown_open = 1
 
 " the port on which Livedown server will run
 let g:livedown_port = 1337
 
-" the browser to use
+" the browser to use, can also be firefox, chrome or other, depending on your executable
 let g:livedown_browser = "safari"
 ```
 

--- a/plugin/livedown.vim
+++ b/plugin/livedown.vim
@@ -23,9 +23,17 @@ if !exists('g:livedown_command')
   endif
 endif
 
+function! s:LivedownChromeName()
+  if has('macunix')
+    return "'Google Chrome'"
+  elseif has('unix')
+    return 'google-chrome'
+  endif
+endfunction
+
 function! s:LivedownBrowser()
-  if g:livedown_browser == "chrome" && has('macunix')
-    let l:browser = "'Google Chrome'"
+  if g:livedown_browser =~ '\c\(google\)\?[ -]\?chrome'
+    let l:browser = s:LivedownChromeName()
   else
     let l:browser = g:livedown_browser
   endif


### PR DESCRIPTION
Why:

* In order to get Chrome to work, we would have to set the
`g:livedown_browser` variable to be exactly "google-chrome" in Linux and
"chrome" in macOS.
* This behaviour is confusing for the users.

This change addresses the need by:

* Allowing multiple variations of Chrome as the variable value, in order
to be backwards compatible (`Google Chrome`, `chrome`, `google-chrome`,
`google chrome`) all work, regardless of the OS.
* Updating the README to ensure the most common options are present.

See: https://github.com/shime/vim-livedown/issues/27#issuecomment-464699931